### PR TITLE
Switched `control` to `alt` in Element.Event.Pseudos

### DIFF
--- a/demos/Element.Event.Pseudos/demo.css
+++ b/demos/Element.Event.Pseudos/demo.css
@@ -7,7 +7,7 @@
 
 .item {
 	height: 40px;
-	width:40px;
+	width: 40px;
 	margin: 4px;
 	float: left;
 	background-color: #78BA91;

--- a/demos/Element.Event.Pseudos/demo.html
+++ b/demos/Element.Event.Pseudos/demo.html
@@ -1,9 +1,9 @@
 <h2>Only fires once:</h2>
 <a href="#" id="clickOnce">Click me and I'll just fire once and no more!</a>
 
-<h2><code>:ctrl</code> Pseudo</h2>
+<h2><code>:alt</code> Pseudo</h2>
 
-<p>Hold the <code>Ctrl</code> key and click a block to toggle the <code>.active</code> class.</p>
+<p>Hold the <code>Alt</code> key and click a block to toggle the <code>.active</code> class.</p>
 
 <div id="container" >
 	<div class="item"></div>

--- a/demos/Element.Event.Pseudos/demo.js
+++ b/demos/Element.Event.Pseudos/demo.js
@@ -11,14 +11,14 @@ window.addEvent('domready', function() {
 		}).tween('margin-left', 300);
 	});
 
-	// we can define our own pseudo events as well, for example to check for the control key
-	Event.definePseudo('ctrl', function(split, fn, args){
+	// we can define our own pseudo events as well, for example to check for the alt key
+	Event.definePseudo('alt', function(split, fn, args){
 		// args[0] is the Event instance
-		if(args[0].control) fn.apply(this, args);
+		if(args[0].alt) fn.apply(this, args);
 	});
 
 	// apply the psuedo event to some elements
-	$$('.item').addEvent('click:ctrl', function(){
+	$$('.item').addEvent('click:alt', function(){
 		this.toggleClass('active');
 	});
 


### PR DESCRIPTION
Click + control on MacOS triggers the context menu, hence the demo was unusable. Switched Control to Alt 
